### PR TITLE
Change Key CONTROL constant to CTRL to match Sikuli's

### DIFF
--- a/lackey/KeyCodes.py
+++ b/lackey/KeyCodes.py
@@ -44,7 +44,7 @@ class Key():
     PRINTSCREEN = "{PRINTSCREEN}"
     ALT 		= "{ALT}"
     CMD 		= "{CMD}"
-    CONTROL 	= "{CTRL}"
+    CTRL 	= "{CTRL}"
     META 		= "{META}"
     SHIFT 		= "{SHIFT}"
     WIN 		= "{WIN}"

--- a/tests/multiprocessing_test.py
+++ b/tests/multiprocessing_test.py
@@ -23,7 +23,7 @@ def main():
     time.sleep(7)
     r.rightClick(lackey.Pattern("test_text.png").similar(0.6))
     r.click("select_all.png")
-    r.type("c", lackey.Key.CONTROL) # Copy
+    r.type("c", lackey.Key.CTRL) # Copy
     assert r.getClipboard() == "This is a test"
     r.type("{DELETE}")
     r.type("{F4}", lackey.Key.ALT)

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -47,13 +47,13 @@ class TestComplexFeatures(unittest.TestCase):
         r = app.window()
 
         r.type("This is a Test")
-        r.type("a", lackey.Key.CONTROL) # Select all
-        r.type("c", lackey.Key.CONTROL) # Copy
+        r.type("a", lackey.Key.CTRL) # Select all
+        r.type("c", lackey.Key.CTRL) # Copy
         self.assertEqual(r.getClipboard(), "This is a Test")
         r.type("{DELETE}") # Clear the selected text
         r.paste("This, on the other hand, is a {SHIFT}broken {SHIFT}record.") # Paste should ignore special characters and insert the string as is
-        r.type("a", lackey.Key.CONTROL) # Select all
-        r.type("c", lackey.Key.CONTROL) # Copy
+        r.type("a", lackey.Key.CTRL) # Select all
+        r.type("c", lackey.Key.CTRL) # Copy
         self.assertEqual(r.getClipboard(), "This, on the other hand, is a {SHIFT}broken {SHIFT}record.")
 
         if sys.platform.startswith("win"):
@@ -84,7 +84,7 @@ class TestComplexFeatures(unittest.TestCase):
         r.rightClick(r.getLastMatch())
         self.assertGreater(r.getTime(), 0)
         r.click("select_all.png")
-        r.type("c", lackey.Key.CONTROL) # Copy
+        r.type("c", lackey.Key.CTRL) # Copy
         self.assertEqual(r.getClipboard(), "This is a test")
         r.type("{DELETE}")
         r.type("{F4}", lackey.Key.ALT)


### PR DESCRIPTION
For the Control key, Sikuli's Key class has the CTRL constant (not CONTROL), so sikuli scripts using `Key.CTRL` currently throw an error in lackey.

See below:
http://sikulix-2014.readthedocs.io/en/latest/keys.html
http://doc.sikuli.org/javadoc/org/sikuli/script/Key.html

Not sure if there was a specific reason for this - it's CTRL in the KeyModifier class, and the other constants are identical, except for the additional F16 in lackey (and I see the keyboard library supports them up to F24 anyway).