### PR TITLE
Fix type() not parsing multiple special key codes

### DIFF
--- a/lackey/InputEmulation.py
+++ b/lackey/InputEmulation.py
@@ -367,6 +367,7 @@ class Keyboard(object):
                     # Release the rest of the keys normally
                     self.type(special_code)
                     self.type(text[i])
+                special_code = ""
             elif in_special_code:
                 special_code += text[i]
             elif text[i] in self._REGULAR_KEYCODES.keys():


### PR DESCRIPTION
This adds a missing `special_code = ""` in Keyboard's `type()` method (it is present in `keyUp `and `keyDown` though). It fails with several keycodes as it keeps appending to the string. So `type('{TAB}{TAB}')` or `type(Key.TAB + Key.TAB)` will produce {TABTAB} instead of tabbing twice.

I added a test for different parsing scenarios with special key codes just in case. The best way I could think of was to open notepad and test expected outputs, so this changes the `TestKeyboardMethods` a bit (and runs on windows only). Hope it's not too convoluted though! 