### PR TITLE
Fix tests failing at getWindow() if file extensions hidden

### DIFF
--- a/tests/appveyor_test_cases.py
+++ b/tests/appveyor_test_cases.py
@@ -7,6 +7,12 @@ import sys
 import os
 import lackey
 
+# Python 2/3 compatibility
+try:
+    unittest.TestCase.assertRegex
+except AttributeError:
+    unittest.TestCase.assertRegex =  unittest.TestCase.assertRegexpMatches
+
 class TestMouseMethods(unittest.TestCase):
     def setUp(self):
         self.mouse = lackey.Mouse()
@@ -34,7 +40,7 @@ class TestAppMethods(unittest.TestCase):
 
         self.assertEqual(app.getName(), "notepad.exe")
         self.assertTrue(app.isRunning())
-        self.assertEqual(app.getWindow(), "test_cases.py - Notepad")
+        self.assertRegex(app.getWindow(), "test_cases(.py)? - Notepad")
         self.assertNotEqual(app.getPID(), -1)
         region = app.window()
         self.assertIsInstance(region, lackey.Region)
@@ -52,7 +58,7 @@ class TestAppMethods(unittest.TestCase):
         lackey.wait(1)
         self.assertEqual(app.getName(), "notepad.exe")
         self.assertTrue(app.isRunning())
-        self.assertEqual(app.getWindow(), "test_cases.py - Notepad")
+        self.assertRegex(app.getWindow(), "test_cases(.py)? - Notepad")
         self.assertNotEqual(app.getPID(), -1)
         app.close()
         lackey.wait(0.9)


### PR DESCRIPTION
Sorry if this is super trivial, but see if it's worth adding :) 2 tests will always fail for me if file extensions are hidden on Windows (see below). I just added this so both tests pass regardless of the settings in Windows.
```
======================================================================
FAIL: test_getters (tests.appveyor_test_cases.TestAppMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lackey\tests\appveyor_test_cases.py", line 37, in test_getters
    self.assertEqual(app.getWindow(), "test_cases.py - Notepad")
AssertionError: 'test_cases - Notepad' != 'test_cases.py - Notepad'
- test_cases - Notepad
+ test_cases.py - Notepad
?           +++


======================================================================
FAIL: test_launchers (tests.appveyor_test_cases.TestAppMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lackey\tests\appveyor_test_cases.py", line 55, in test_launchers
    self.assertEqual(app.getWindow(), "test_cases.py - Notepad")
AssertionError: 'test_cases - Notepad' != 'test_cases.py - Notepad'
- test_cases - Notepad
+ test_cases.py - Notepad
?           +++
```