### PR TITLE
Fix renamed Python built-in functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ My goal with this project is to be able to reuse my existing library of Sikuli s
 
 Note that I *have* had to adjust some of my image search similarity settings in a couple cases. Your mileage may vary. Please report any issues that you encounter and I'll try to get them patched.
 
-Be aware that **some Sikuli-script methods actually overwrite Python-native functions**, namely `type()` and `input()`. Where this is the case, I've remapped the native functions by prefixing them with an underscore. They can be accessed as follows:
+Be aware that **some Sikuli-script methods actually overwrite Python-native functions**, namely `type()` and `input()`. Where this is the case, I've remapped the native functions by adding a trailing underscore. They can be accessed as follows:
 
     from lackey import *
 
-    username = _input("Enter your username: ")
+    username = input_("Enter your username: ")
 
 ## Structure ##
 

--- a/lackey/__init__.py
+++ b/lackey/__init__.py
@@ -53,10 +53,7 @@ keyboard.add_hotkey("alt+shift+c", _abort_script, suppress=True)
 
 type_ = type
 input_ = input
-try:
-    exit_ = exit
-except NameError:
-    pass # `exit` is not always defined, as when building to executable.
+exit_ = sys.exit
 #zip_ = zip
 
 ## Sikuli Convenience Functions

--- a/lackey/__init__.py
+++ b/lackey/__init__.py
@@ -22,6 +22,7 @@ except ImportError:
 import sys
 import time
 import os
+import warnings
 import requests
 
 ## Lackey sub-files
@@ -55,6 +56,22 @@ type_ = type
 input_ = input
 exit_ = sys.exit
 #zip_ = zip
+
+
+# Deprecated underscore functions
+
+def _exit(code):
+    warnings.warn("Please use exit_ instead.", DeprecationWarning)
+    return exit_(code)
+
+def _input(prompt):
+    warnings.warn("Please use input_ instead.", DeprecationWarning)
+    return input_(prompt)
+
+def _type(obj):
+    warnings.warn("Please use type_ instead.", DeprecationWarning)
+    return type_(obj)
+
 
 ## Sikuli Convenience Functions
 

--- a/lackey/__init__.py
+++ b/lackey/__init__.py
@@ -51,13 +51,13 @@ keyboard.add_hotkey("alt+shift+c", _abort_script, suppress=True)
 
 # First, save the native functions by remapping them with a prefixed underscore:
 
-_type = type
-_input = input
+type_ = type
+input_ = input
 try:
-    _exit = exit
+    exit_ = exit
 except NameError:
     pass # `exit` is not always defined, as when building to executable.
-#_zip = zip
+#zip_ = zip
 
 ## Sikuli Convenience Functions
 

--- a/lackey/__init__.py
+++ b/lackey/__init__.py
@@ -50,7 +50,7 @@ keyboard.add_hotkey("alt+shift+c", _abort_script, suppress=True)
 ## Sikuli patching: Functions that map to the global Screen region
 ## Don't try this at home, kids!
 
-# First, save the native functions by remapping them with a prefixed underscore:
+# First, save the native functions by remapping them with a trailing underscore:
 
 type_ = type
 input_ = input

--- a/tests/appveyor_test_cases.py
+++ b/tests/appveyor_test_cases.py
@@ -567,6 +567,11 @@ class TestConvenienceFunctions(unittest.TestCase):
         self.assertHasMethod(lackey, "select", 4)
         self.assertHasMethod(lackey, "popFile", 1)
 
+    def test_renamed_builtin_functions(self):
+        self.assertEqual(lackey.exit_, sys.exit)
+        self.assertEqual(lackey.input_, input)
+        self.assertEqual(lackey.type_, type)
+
     def assertHasMethod(self, cls, mthd, args=0):
         """ Custom test to make sure a class has the specified method (and that it takes `args` parameters) """
         self.assertTrue(callable(getattr(cls, mthd, None)))


### PR DESCRIPTION
Fixes #104.

This will:
- use trailing instead of leading underscores to fix usage with `from lackey import *`
- use `sys.exit()` instead of `exit()` helper function to simplify usage with executables
- add deprecation warning for old functions (only useful with the `-Wd` option or the `logging` package, but just in case)
- add basic tests