### PR TITLE
Fix waitForWindow() on Mac and Windows.

### DIFF
--- a/lackey/App.py
+++ b/lackey/App.py
@@ -194,7 +194,7 @@ class App(object):
                 return ""
             return PlatformManager.getWindowTitle(PlatformManager.getWindowByPID(self.getPID()))
         else:
-            return None
+            return ""
     def getName(self):
         """ Returns the short name of the app as shown in the process list """
         return PlatformManager.getProcessName(self.getPID())

--- a/lackey/App.py
+++ b/lackey/App.py
@@ -190,9 +190,11 @@ class App(object):
         Returns an empty string if no match could be found.
         """
         if self.getPID() != -1:
+            if not self.hasWindow():
+                return ""
             return PlatformManager.getWindowTitle(PlatformManager.getWindowByPID(self.getPID()))
         else:
-            return ""
+            return None
     def getName(self):
         """ Returns the short name of the app as shown in the process list """
         return PlatformManager.getProcessName(self.getPID())
@@ -213,7 +215,7 @@ class App(object):
         timeout = time.time() + seconds
         while True:
             window_region = self.window()
-            if window_region is not None or time.time() < timeout:
+            if window_region is not None or time.time() > timeout:
                 break
             time.sleep(0.5)
         return window_region
@@ -223,6 +225,8 @@ class App(object):
         Defaults to the first window found for the corresponding PID.
         """
         if self._pid == -1:
+            return None
+        if not self.hasWindow():
             return None
         x,y,w,h = PlatformManager.getWindowRect(PlatformManager.getWindowByPID(self._pid, windowNum))
         return Region(x,y,w,h).clipRegionToScreen()

--- a/lackey/PlatformManagerDarwin.py
+++ b/lackey/PlatformManagerDarwin.py
@@ -318,7 +318,7 @@ class PlatformManagerDarwin(object):
                     return w["kCGWindowNumber"]
                 else:
                     order -= 1
-        raise OSError("Could not find window for PID {} at index {}".format(pid, order))
+        return None
     def getWindowRect(self, hwnd):
         """ Returns a rect (x,y,w,h) for the specified window's area """
         for w in self._get_window_list():
@@ -328,7 +328,7 @@ class PlatformManagerDarwin(object):
                 width = w["kCGWindowBounds"]["Width"]
                 height = w["kCGWindowBounds"]["Height"]
                 return (x, y, width, height)
-        raise OSError("Unrecognized window number {}".format(hwnd))
+        return None
     def focusWindow(self, hwnd):
         """ Brings specified window to the front """
         Debug.log(3, "Focusing window: " + str(hwnd))


### PR DESCRIPTION
Avoid exception when getWindow() or getWindowTitle() is called while window isn't open yet and waiting for window.
On Mac, return None instead of raising exception when PID window isn't found