### PR TITLE
`compare()` throws a `NameError`

### DIFF
--- a/lackey/RegionMatching.py
+++ b/lackey/RegionMatching.py
@@ -1368,7 +1368,7 @@ class Region(object):
         return best_match
     def compare(self, image):
         """ Compares the region to the specified image """
-        return exists(Pattern(image), 0)
+        return self.exists(Pattern(image), 0)
     def findText(self, text, timeout=None):
         """ OCR function """
         raise NotImplementedError()


### PR DESCRIPTION
When trying to use `compare()`, I get a the following exception:

```
    return exists(Pattern(image), 0)
NameError: name 'exists' is not defined
```

Looks like it should be calling the instance method instead?