### PR TITLE
Not check elevated user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ Temporary Items
 logfile.txt
 
 .vscode/settings.json
+
+# virtual env
+venv/

--- a/lackey/InputEmulation.py
+++ b/lackey/InputEmulation.py
@@ -13,6 +13,8 @@ try:
 except NameError:
     basestring = str
 
+from .SettingsDebug import Debug, Settings
+
 class Mouse(object):
     """ Mid-level mouse routines. """
     def __init__(self):
@@ -66,10 +68,12 @@ class Mouse(object):
         original_location = mouse.get_position()
         mouse.move(location.x, location.y, duration=seconds)
         if mouse.get_position() == original_location and original_location != location.getTuple():
-            raise IOError("""
-                Unable to move mouse cursor. This may happen if you're trying to automate a 
-                program running as Administrator with a script running as a non-elevated user.
-            """)
+            if Settings.CheckElevatedUser:
+                raise IOError( """
+                    Unable to move mouse cursor. This may happen if you're trying to automate a
+                    program running as Administrator with a script running as a non-elevated user.
+                """)
+            Debug.error('Unable to move mouse cursor.')
         self._lock.release()
 
     def click(self, loc=None, button=mouse.LEFT):

--- a/lackey/SettingsDebug.py
+++ b/lackey/SettingsDebug.py
@@ -163,6 +163,7 @@ class SettingsMaster(object):
     DelayBeforeDrop = 0.3
     ClickDelay = 0.0 # Resets to 0 after next click
     TypeDelay = 0.0 # Resets to 0 after next keypress
+    CheckElevatedUser = True  # False don't check elevated user
 
     ## Action Settings
     ShowActions = False


### PR DESCRIPTION
Added option to not check elevated privileges for the user. 
Purpose: to ignore IOError in specific cases.
There are some situations where the non-response of the mouse does not occur due to an error in the user's privileges, but because the application has stopped responding.
The default value does not change how Lackey works.
Thanks